### PR TITLE
[bugfix] ensure key-pressed does not generate error in child thread

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Terminal-ReadKey
 
 {{$NEXT}}
+    - [bugfix] Eliminate error inside async thread due to wrong return type
 
 0.0.1  2022-12-22T09:47:52-05:00
     - Initial version

--- a/META6.json
+++ b/META6.json
@@ -24,6 +24,7 @@
     "read key"
   ],
   "test-depends": [
+    "Test::Mock"
   ],
   "version": "0.0.1"
 }

--- a/lib/Terminal/ReadKey.rakumod
+++ b/lib/Terminal/ReadKey.rakumod
@@ -399,7 +399,7 @@ sub cooked ($char, :$layout = 'US') is export(:cooked) {
 
 use Term::termios;
 
-sub with-termios(Callable:D $fn, Bool:D :$echo = True --> Str) {
+sub with-termios(Callable:D $fn, Bool:D :$echo = True) is export(:_testing) {
     my $original-flags := Term::termios.new(:fd($*IN.native-descriptor)).getattr;
     my $flags := Term::termios.new(:fd($*IN.native-descriptor)).getattr;
 

--- a/lib/Terminal/ReadKey.rakumod
+++ b/lib/Terminal/ReadKey.rakumod
@@ -3,6 +3,7 @@ unit module Terminal::ReadKey;
 use Term::termios;
 
 our %keyboard;
+our $termios = Term::termios;
 
 %keyboard<US> =  { # "cooked" mode key press hash, US layout
     Buf.new(0).decode => ｢Ctrl `｣,
@@ -397,17 +398,15 @@ sub cooked ($char, :$layout = 'US') is export(:cooked) {
     $char
 }
 
-use Term::termios;
-
 sub with-termios(Callable:D $fn, Bool:D :$echo = True) is export(:_testing) {
-    my $original-flags := Term::termios.new(:fd($*IN.native-descriptor)).getattr;
-    my $flags := Term::termios.new(:fd($*IN.native-descriptor)).getattr;
+    my $original-flags := $termios.new(:fd($*IN.native-descriptor)).getattr;
+    my $flags := $termios.new(:fd($*IN.native-descriptor)).getattr;
 
     $flags.unset_lflags('ICANON');
     $flags.unset_lflags('ECHO') unless $echo;
     $flags.setattr(:NOW);
 
-    my $result = $fn();
+    my $result := $fn();
     $original-flags.setattr(:NOW);
     $result;
 }

--- a/t/99-bug-return-type.rakutest
+++ b/t/99-bug-return-type.rakutest
@@ -1,10 +1,28 @@
 #!/usr/bin/perl
 
 use Test;
+use Test::Mock;
+
+use Term::termios;
 use Terminal::ReadKey (:_testing);
 
-MAIN: {
+sub MAIN {
+    temp $Terminal::ReadKey::termios;
+
+    $Terminal::ReadKey::termios = mocked(
+        Term::termios, overriding => {
+            getattr => -> { $Terminal::ReadKey::termios },
+        }
+    );
+
     lives-ok( { with-termios( sub {} ) }, "with-termios lives");
+
+    # Verify the mock object was called.
+    check-mock($Terminal::ReadKey::termios,
+        *.called('getattr'),
+        *.called('setattr')
+    );
+
     done-testing;
 }
 

--- a/t/99-bug-return-type.rakutest
+++ b/t/99-bug-return-type.rakutest
@@ -1,0 +1,10 @@
+#!/usr/bin/perl
+
+use Test;
+use Terminal::ReadKey (:_testing);
+
+MAIN: {
+    lives-ok( { with-termios( sub {} ) }, "with-termios lives");
+    done-testing;
+}
+


### PR DESCRIPTION
Without this fix, key-pressed() generates an error when the supply is closed, due to the return type being improper on with-termios().  I also created a test case for this condition, but to do so I needed to export with-termios(), so I did so with a `:_testing` tag. Please let me know if you have any concerns or would like me to adjust this patch in any way.

A one-liner demonstrating the problem without the patch:
```
[0] sandbox:~$ raku -MTerminal::ReadKey -e 'react { whenever key-pressed() { done } }; sleep 1'
Unhandled exception in code scheduled on thread 4
Type check failed for return value; expected Str but got Any (Any)
  in sub with-termios at /home/jmaslak/.rakubrew/versions/moar-2021.04/install/share/perl6/site/sources/EFD1A217232DE3AF4D33DEBFF7F0702151E075D6 (Terminal::ReadKey) line 412
  in block  at /home/jmaslak/.rakubrew/versions/moar-2021.04/install/share/perl6/site/sources/EFD1A217232DE3AF4D33DEBFF7F0702151E075D6 (Terminal::ReadKey) line 426
[1] sandbox:~$
```

(Obviously when you run the one-liner, you'll need to press a key for it to exit)

With the patch, there is no error:
```
[0] ubuntu:Terminal-ReadKey$ raku -MTerminal::ReadKey -e 'react { whenever key-pressed() { done } }; sleep 1'
[0] ubuntu:Terminal-ReadKey$ 
```